### PR TITLE
feat: include the alt text

### DIFF
--- a/src/posts.js
+++ b/src/posts.js
@@ -168,6 +168,7 @@ const scrapePosts = async (page, request, itemSpec, entryData) => {
             postLocationId: item.node.location && item.node.location.id || null,
             postOwnerId: item.node.owner && item.node.owner.id || null,
         },
+        alt: item.node.accessibility_caption,
         url: 'https://www.instagram.com/p/' + item.node.shortcode,
         likesCount: item.node.edge_media_preview_like.count,
         imageUrl: item.node.display_url,


### PR DESCRIPTION
Works well for single-image posts but is unfortunately not reliable for multi-image posts and video posts.