### PR TITLE
Grow event loop allowed delay

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -147,6 +147,10 @@ async function main() {
         requestList,
         requestQueue,
         gotoFunction,
+        autoscaledPoolOptions: {
+            snapshotterOptions: { maxBlockedMillis: 500 },
+            systemStatusOptions: { maxEventLoopOverloadedRatio: 0.9 },
+        },
         puppeteerPoolOptions: {
             maxOpenPagesPerInstance: 1,
             retireInstanceAfterRequestCount: 30,


### PR DESCRIPTION
This seems unnecessarily low, growing it so it isn't the primary constraint - allowing callbacks to take half a second to be scheduled seems fine compared to the pupetter timeouts
