### PR TITLE
fix request not using proxies

### DIFF
--- a/apify.json
+++ b/apify.json
@@ -2,6 +2,6 @@
 	"name": "instagram-scraper",
 	"version": "0.0",
 	"buildTag": "latest",
-	"env": { "npm_config_loglevel": "silent" },
+	"env": { "npm_config_loglevel": "silent", "APIFY_LOG_LEVEL": "DEBUG" },
 	"template": "puppeteer_crawler"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -41,12 +41,13 @@ async function main() {
     let maxConcurrency = 1000;
 
     const usingLogin = loginCookies && Array.isArray(loginCookies);
+    let proxySession;
 
     if (usingLogin) {
         Apify.utils.log.warning('Cookies were used, setting maxConcurrency to 1 and using one proxy session!');
         maxConcurrency = 1;
         const session = crypto.createHash('sha256').update(JSON.stringify(loginCookies)).digest('hex').substring(0,16)
-        if (proxy.useApifyProxy) proxy.apifyProxySession = `insta_session_${session}`;
+        if (proxy.useApifyProxy) proxySession = proxy.apifyProxySession = `insta_session_${session}`;
     }
 
     try {
@@ -72,7 +73,7 @@ async function main() {
         Apify.utils.log.warning('Search is disabled when Direct URLs are used');
         urls = directUrls
     } else {
-        urls = await searchUrls(input);
+        urls = await searchUrls(input, proxy ? Apify.getApifyProxyUrl({ groups: proxy.apifyProxyGroups, session: proxySession }) : undefined);
     }
 
     const requestListSources = urls.map((url) => ({

--- a/src/index.js
+++ b/src/index.js
@@ -245,7 +245,7 @@ async function main() {
         launchPuppeteerOptions: {
             ...proxy,
             stealth: true,
-            useChrome: true,
+            useChrome: Apify.isAtHome(),
             ignoreHTTPSErrors: true,
             args: ['--enable-features=NetworkService', '--ignore-certificate-errors'],
         },

--- a/src/search.js
+++ b/src/search.js
@@ -12,7 +12,7 @@ const formatHashtagResult = item => `https://www.instagram.com/explore/tags/${it
  * Attempts to query Instagram search and parse found results into direct links to instagram pages
  * @param {Object} input Input loaded from Apify.getInput();
  */
-const searchUrls = async (input, proxy) => {
+const searchUrls = async (input, proxy, isRetry = false) => {
     const { search, searchType, searchLimit = 10 } = input;
     if (!search) return [];
 
@@ -40,8 +40,17 @@ const searchUrls = async (input, proxy) => {
 
     Apify.utils.log.debug('Response', { response });
 
-    if (typeof response !== 'object' && process.env.APIFY_LOG_LEVEL === 'DEBUG') {
-        await Apify.setValue(`RESPONSE-${Math.random()}`, response, { contentType: 'text/plain' });
+    if (typeof response !== 'object') {
+        if (process.env.APIFY_LOG_LEVEL === 'DEBUG') {
+            await Apify.setValue(`RESPONSE-${Math.random()}`, response, { contentType: 'text/plain' });
+        }
+
+        if (!isRetry) {
+            Apify.utils.log.warning('Server returned non-json answer, retrying one more time');
+            return searchUrls(input, proxy, true);
+        }
+
+        throw new Error('Search is blocked on current proxy IP');
     }
 
     let urls;

--- a/src/search.js
+++ b/src/search.js
@@ -12,7 +12,7 @@ const formatHashtagResult = item => `https://www.instagram.com/explore/tags/${it
  * Attempts to query Instagram search and parse found results into direct links to instagram pages
  * @param {Object} input Input loaded from Apify.getInput();
  */
-const searchUrls = async (input) => {
+const searchUrls = async (input, proxy) => {
     const { search, searchType, searchLimit = 10 } = input;
     if (!search) return [];
 
@@ -35,6 +35,7 @@ const searchUrls = async (input) => {
     const response = await request({
         url: searchUrl,
         json: true,
+        proxy,
     });
 
     Apify.utils.log.debug('Response', { response });

--- a/src/search.js
+++ b/src/search.js
@@ -39,6 +39,10 @@ const searchUrls = async (input) => {
 
     Apify.utils.log.debug('Response', { response });
 
+    if (typeof response !== 'object' && process.env.APIFY_LOG_LEVEL === 'DEBUG') {
+        await Apify.setValue(`RESPONSE-${Math.random()}`, response, { contentType: 'text/plain' });
+    }
+
     let urls;
     if (searchType === SEARCH_TYPES.USER) urls = response.users.map(formatUserResult);
     else if (searchType === SEARCH_TYPES.PLACE) urls = response.places.map(formatPlaceResult);

--- a/src/search.js
+++ b/src/search.js
@@ -37,6 +37,8 @@ const searchUrls = async (input) => {
         json: true,
     });
 
+    Apify.utils.log.debug('Response', response);
+
     let urls;
     if (searchType === SEARCH_TYPES.USER) urls = response.users.map(formatUserResult);
     else if (searchType === SEARCH_TYPES.PLACE) urls = response.places.map(formatPlaceResult);

--- a/src/search.js
+++ b/src/search.js
@@ -37,7 +37,7 @@ const searchUrls = async (input) => {
         json: true,
     });
 
-    Apify.utils.log.debug('Response', response);
+    Apify.utils.log.debug('Response', { response });
 
     let urls;
     if (searchType === SEARCH_TYPES.USER) urls = response.users.map(formatUserResult);


### PR DESCRIPTION
Since the initial searchUrl request isn't using the provided proxies (but the containers IP), the request hardfails returning HTML instead of JSON. this is a blocker for people using search, and happens with any search mode. this effectively passes the selected proxy group crafted url to the initial search request. this initial request will be retried ONCE, otherwise it will fail with a descriptive error

fixes #68 

Sample run: https://my.apify.com/view/runs/A9RHkQpp73bXTRrCS
Failing run: https://my.apify.com/view/runs/R8vsndCAnSBKubBYe

