### PR TITLE
fix "Found non-callable @@iterator"

### DIFF
--- a/src/cookies.js
+++ b/src/cookies.js
@@ -47,7 +47,7 @@ const LoginCookiesStore = class CookiesStore {
         for (const key in this.cookiesStore) {
             if (!this.cookiesStore[key].browserPid) keys.push(key)
         }
-        if (keys.length === 0) return {};
+        if (keys.length === 0) return null;
         // check active instances && cleanup used cookies
         if (this.puppeteerPool) {
             const pids = this.activeBrowserPids(this.puppeteerPool);

--- a/src/index.js
+++ b/src/index.js
@@ -331,7 +331,7 @@ async function main() {
         });
 
         const cookies = loginCookiesStore.randomCookie(browser.process().pid);
-        if (cookies) {
+        if (cookies && cookies.length) {
             const page = await browser.newPage();
             await page.setCookie(...cookies);
         }


### PR DESCRIPTION
when using loginCookies, the check for `{}` is truthy, but it's not iterable. it fails after a while with:

```
2020-10-20T02:40:46.072Z   TypeError: Found non-callable @@iterator
2020-10-20T02:40:46.074Z       at launchPuppeteerFunction (/home/myuser/src/index.js:336:24)
2020-10-20T02:40:46.076Z       at runMicrotasks (<anonymous>)
2020-10-20T02:40:46.078Z       at processTicksAndRejections (internal/process/task_queues.js:97:5)
2020-10-20T02:40:46.081Z       at async PuppeteerInstance.PuppeteerPool.launchPuppeteerFunction (/home/myuser/node_modules/apify/build/puppeteer_pool.js:257:29)
```