### PR TITLE
Update scraping using additional xhr request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1128,11 +1128,6 @@
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
 			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
 		},
-		"cookie": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-			"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
-		},
 		"cookie-signature": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -1593,6 +1588,11 @@
 				"resolve": "^1.13.1"
 			},
 			"dependencies": {
+				"cookie": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+					"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+				},
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/src/consts.js
+++ b/src/consts.js
@@ -68,5 +68,16 @@ module.exports = {
         'es6/en',
         'es6/Vendor',
         'es6/ActivityFeedBox'
-    ]
+    ],
+    HEADERS: {
+        "access-control-expose-headers": 'X-IG-Set-WWW-Claim',
+        accept: '*/*',
+        'accept-encoding': 'gzip, deflate, br',
+        'sec-fetch-dest': 'empty',
+        'sec-fetch-mode': 'cors',
+        'sec-fetch-site': 'same-origin',
+        'x-ig-app-id': '936619743392459',
+        'x-ig-www-claim': 'hmac.AR1-yiYTI0KAovABgcl_mYe5lSWZC3Jtjc8gMfXTp8Z2t6gQ',
+        'x-requested-with': 'XMLHttpRequest',
+    }
 };

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -30,7 +30,6 @@ const LoginCookiesStore = class CookiesStore {
         this.cookiesStore[key] = {};
         this.cookiesStore[key]['cookies'] = loginCookies;
         this.cookiesStore[key].browserPid = null;
-        this.cookiesStore[key].proxyUrl = null;
         this.cookiesStore[key].errorCount = 0;
     }
 
@@ -43,7 +42,7 @@ const LoginCookiesStore = class CookiesStore {
         return Math.floor(this.cookiesCount() / this.cookiesPerConcurrency);
     }
 
-    randomCookie(browserPid = null, proxyUrl = null) {
+    randomCookie(browserPid = null) {
         if (!this.usingLogin()) return null;
         const keys = []
         for (const key in this.cookiesStore) {
@@ -61,14 +60,12 @@ const LoginCookiesStore = class CookiesStore {
 
         const cookieKey = keys[(Math.floor(Math.random() * keys.length))];
         this.cookiesStore[cookieKey].browserPid = browserPid;
-        this.cookiesStore[cookieKey].proxyUrl = proxyUrl;
         Apify.utils.log.debug(`Selected cookies session: ${cookieKey}`);
         return this.cookiesStore[cookieKey]['cookies'];
     }
 
     releaseCookie(cookieKey) {
         this.cookiesStore[cookieKey].browserPid = null;
-        this.cookiesStore[cookieKey].proxyUrl = null;
     }
 
     cookiesCount() {
@@ -105,11 +102,6 @@ const LoginCookiesStore = class CookiesStore {
             if (this.cookiesStore[key].browserPid === browserPid)
                 return key;
         }
-    }
-
-    proxyUrl(browserPid) {
-        const cookieKey = this.browserCookies(browserPid);
-        return this.cookiesStore[cookieKey].proxyUrl;
     }
 
     invalidCookies() {

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -30,6 +30,7 @@ const LoginCookiesStore = class CookiesStore {
         this.cookiesStore[key] = {};
         this.cookiesStore[key]['cookies'] = loginCookies;
         this.cookiesStore[key].browserPid = null;
+        this.cookiesStore[key].proxyUrl = null;
         this.cookiesStore[key].errorCount = 0;
     }
 
@@ -42,7 +43,7 @@ const LoginCookiesStore = class CookiesStore {
         return Math.floor(this.cookiesCount() / this.cookiesPerConcurrency);
     }
 
-    randomCookie(browserPid = null) {
+    randomCookie(browserPid = null, proxyUrl = null) {
         if (!this.usingLogin()) return null;
         const keys = []
         for (const key in this.cookiesStore) {
@@ -60,12 +61,14 @@ const LoginCookiesStore = class CookiesStore {
 
         const cookieKey = keys[(Math.floor(Math.random() * keys.length))];
         this.cookiesStore[cookieKey].browserPid = browserPid;
+        this.cookiesStore[cookieKey].proxyUrl = proxyUrl;
         Apify.utils.log.debug(`Selected cookies session: ${cookieKey}`);
         return this.cookiesStore[cookieKey]['cookies'];
     }
 
     releaseCookie(cookieKey) {
         this.cookiesStore[cookieKey].browserPid = null;
+        this.cookiesStore[cookieKey].proxyUrl = null;
     }
 
     cookiesCount() {
@@ -102,6 +105,11 @@ const LoginCookiesStore = class CookiesStore {
             if (this.cookiesStore[key].browserPid === browserPid)
                 return key;
         }
+    }
+
+    proxyUrl(browserPid) {
+        const cookieKey = this.browserCookies(browserPid);
+        return this.cookiesStore[cookieKey].proxyUrl;
     }
 
     invalidCookies() {

--- a/src/errors.js
+++ b/src/errors.js
@@ -14,4 +14,5 @@ module.exports = {
     credentialsRequired: () => new Error('You need to provide login credentials.'),
     cookiesNotArray: () => new Error('Login cookies has to be either Array of cookies or Array of Arrays of cookies.'),
     xhrNotLoaded: () => new Error('Required XHR request not loaded.'),
+    storiesNotLoaded: (reelId) => `Stories XHR for reelId: ${reelId}, not loaded correctly. Retrying.`,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -327,7 +327,7 @@ async function main() {
             devtools: !Apify.isAtHome(),
         });
 
-        const cookies = loginCookiesStore.randomCookie(browser.process().pid, proxyUrl);
+        const cookies = loginCookiesStore.randomCookie(browser.process().pid);
         if (cookies && cookies.length) {
             const page = await browser.newPage();
             await page.setCookie(...cookies);

--- a/src/stories.js
+++ b/src/stories.js
@@ -1,11 +1,13 @@
 const Apify = require('apify');
+const { utils: { requestAsBrowser } } = Apify;
+const { storiesNotLoaded } = require('./errors');
 
 /**
  * Takes type of page and data loaded through GraphQL and outputs
  * list of stories.
  * @param {Object} data GraphQL data
  */
-const getStoriesFromGraphQL = ({ data }) => {
+const getStoriesFromGraphQL = (data) => {
     if (!data) return;
     const { reels_media } = data;
     const itemsExists = reels_media && reels_media[0] && reels_media[0] && reels_media[0].items;
@@ -18,23 +20,73 @@ const getStoriesFromGraphQL = ({ data }) => {
 
 /**
  * Takes GraphQL response, checks that it's a response with more stories and then parses the stories from it
- * @param {Object} page Puppeteer Page object
  * @param {Object} response Puppeteer Response object
  */
-async function handleStoriesGraphQLResponse({ page, response }) {
-    const responseUrl = response.url();
-
-    // Skip queries for other stuff then posts
+async function handleStoriesGraphQLResponse(response) {
+    const responseUrl = response.url;
+    // Check queries for other stuff then stories
     if (!responseUrl.includes('%22reel_ids%22')) return;
 
-    const data = await response.json();
-    const timeline = getStoriesFromGraphQL({ data: data.data });
+    const data = await JSON.parse(response.body);
+    const timeline = getStoriesFromGraphQL(data.data);
 
     Apify.utils.log.info(`Scraped ${timeline.storiesCount} stories`);
     await Apify.pushData(timeline.stories);
-    page.storiesLoaded = true;
+}
+
+/**
+ * Make XHR request to get stories data and store them to dataset
+ * @param {Request} request - request object of main page
+ * @param {PuppeteerPage} page - page object
+ * @param {Object} data - data object loaded from init page
+ * @param {CookiesStore} loginCookiesStore - cookieStore object
+ * @returns {Promise<void>}
+ */
+const scrapeStories = async (request, page, data, loginCookiesStore) => {
+    const browser = await page.browser();
+    if (!data.entry_data.StoriesPage) {
+        Apify.utils.log.warning(`No stories for ${request.url}`);
+        return;
+    }
+    const reelId = data.entry_data.StoriesPage[0].user.id;
+    const url = `https://www.instagram.com/graphql/query/?query_hash=c9c56db64beb4c9dea2d17740d0259d9&variables=%7B%22reel_ids%22%3A%5B%22${reelId}%22%5D%2C%22tag_names%22%3A%5B%5D%2C%22location_ids%22%3A%5B%5D%2C%22highlight_reel_ids%22%3A%5B%5D%2C%22precomposed_overlay%22%3Afalse%2C%22show_story_viewer_list%22%3Atrue%2C%22story_viewer_fetch_count%22%3A50%2C%22story_viewer_cursor%22%3A%22%22%2C%22stories_video_dash_manifest%22%3Afalse%7D`;
+    const cookies = await page.cookies();
+    let serializedCookies = '';
+    for (const cookie of cookies) {
+        serializedCookies += `${cookie.name}=${cookie.value}; `;
+    }
+    const userAgent = await page.evaluate(() => navigator.userAgent);
+    const headers = {
+        referer: request.url,
+        "x-csrftoken": data.config.csrf_token,
+        cookie: serializedCookies,
+        "access-control-expose-headers": 'X-IG-Set-WWW-Claim',
+        accept: '*/*',
+        'accept-encoding': 'gzip, deflate, br',
+        'sec-fetch-dest': 'empty',
+        'sec-fetch-mode': 'cors',
+        'sec-fetch-site': 'same-origin',
+        'x-ig-app-id': '936619743392459',
+        'x-ig-www-claim': 'hmac.AR1-yiYTI0KAovABgcl_mYe5lSWZC3Jtjc8gMfXTp8Z2t6gQ',
+        'x-requested-with': 'XMLHttpRequest',
+        'user-agent': userAgent,
+    }
+
+    const proxyUrl = loginCookiesStore.proxyUrl(browser.process().pid);
+    const res = await requestAsBrowser({
+        url,
+        timeoutSecs: 30,
+        proxyUrl,
+        headers,
+    });
+
+    if (res.statusCode === 200) {
+        await handleStoriesGraphQLResponse(res);
+    } else {
+        throw storiesNotLoaded(reelId);
+    }
 }
 
 module.exports = {
-    handleStoriesGraphQLResponse,
+    scrapeStories,
 };


### PR DESCRIPTION
Revert blocking of additional request to oriinal state due to increase of network traffick.
Update scraping of stories - no need to us all js and xhr reuests, only one xhr request is done manualy to load stories information.
Update scraping of hasPublicStory for detail page, same as stories.