### PR TITLE
add parsePageScript

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -787,6 +787,22 @@ const handleResponse = async (response) => {
     return responseObject;
 };
 
+/**
+ * Parses the script file if there is no valid XHR
+ * @param { Puppeteer.Page } page
+ * @returns
+*/
+
+const parsePageScript = async (page) => {
+    const scripts = await page.$$eval('script', scripts => scripts.map(script => script.innerHTML));
+    for (const script of scripts) {
+        if (script.includes('highlight_reel_count')) {
+            const json = script.split(`"result":`)?.[1]?.slice(0, -15);
+            return eval(`(${JSON.parse(json).response})`).data.user;
+        }
+    }
+}
+
 module.exports = {
     getPageTypeFromUrl,
     getCheckedVariable,
@@ -816,4 +832,5 @@ module.exports = {
     edgesToText,
     secondsToDate,
     handleResponse,
+    parsePageScript,
 };

--- a/src/scraper-public.js
+++ b/src/scraper-public.js
@@ -33,14 +33,14 @@ class PublicScraper extends BaseScraper {
      */
     async formatProfileOutput(context, ig) {
         const { includeTaggedPosts, includeRelatedProfiles } = this.options.input;
+        const { request: { userData } } = context;
         const following = await this.getProfileFollowing(context, ig);
         const followedBy = await this.getProfileFollowers(context, ig);
         const taggedPosts = includeTaggedPosts ? await this.getTaggedPosts(context, ig) : [];
 
         const { entryData } = ig;
 
-        const data = context.request.userData?.userInfo?.data?.user || context.request.userData?.jsonResponse?.data?.data?.user || entryData?.ProfilePage[0]?.graphql?.user;
-
+        const data = userData?.userInfo?.data?.user || userData?.jsonResponse?.data?.data?.user || await helpers.parsePageScript(context.page);
         const result = {
             id: data.pk || data.id,
             username: data.username,
@@ -72,7 +72,6 @@ class PublicScraper extends BaseScraper {
             taggedPosts,
             hasPublicStory: data.has_public_story,
         };
-
         return result;
     }
 

--- a/src/scraper-public.js
+++ b/src/scraper-public.js
@@ -33,14 +33,12 @@ class PublicScraper extends BaseScraper {
      */
     async formatProfileOutput(context, ig) {
         const { includeTaggedPosts, includeRelatedProfiles } = this.options.input;
-        const { request: { userData } } = context;
+        const { request: { userData }, page } = context;
         const following = await this.getProfileFollowing(context, ig);
         const followedBy = await this.getProfileFollowers(context, ig);
         const taggedPosts = includeTaggedPosts ? await this.getTaggedPosts(context, ig) : [];
 
-        const { entryData } = ig;
-
-        const data = userData?.userInfo?.data?.user || userData?.jsonResponse?.data?.data?.user || await helpers.parsePageScript(context.page);
+        const data = userData?.userInfo?.data?.user || userData?.jsonResponse?.data?.data?.user || await helpers.parsePageScript(page);
         const result = {
             id: data.pk || data.id,
             username: data.username,


### PR DESCRIPTION
Sometimes we can't get a valid XHR, but still able to retrieve data from <script>. Added a parser as a backup for those cases. Tested with [Simone Simons'](https://www.instagram.com/simonesimons/?hl=en) page with no cookies. 