### PR TITLE
Hashtags fix (with cookie)

### DIFF
--- a/src/actor-disable.js
+++ b/src/actor-disable.js
@@ -12,15 +12,18 @@ module.exports.maybeDisableActor = (input) => {
 
     const isProfileToDetails = pageType === PAGE_TYPES.PROFILE && input.resultsType === SCRAPE_TYPES.DETAILS;
     const isPostToDetails = pageType === PAGE_TYPES.POST && input.resultsType === SCRAPE_TYPES.DETAILS;
+    const isPostToComments = pageType === PAGE_TYPES.POST && input.resultsType === SCRAPE_TYPES.COMMENTS;
+    const isPlacesPostsWithCookie = pageType === PAGE_TYPES.PLACE && input.resultsType === SCRAPE_TYPES.POSTS && input.loginCookies?.length;
     const isProfileToPosts = pageType === PAGE_TYPES.PROFILE && input.resultsType === SCRAPE_TYPES.POSTS;
+    const isPostsToHashtagsWithCookie = pageType === PAGE_TYPES.HASHTAG && input.resultsType === SCRAPE_TYPES.POSTS && input.loginCookies?.length;
     const isLogin = input.loginCookies?.length > 0;
-    if (isProfileToDetails || isPostToDetails || (isProfileToPosts && isLogin)) {
+    if (isProfileToDetails || isPostToDetails || (isProfileToPosts && isLogin) || isPostToComments || isPlacesPostsWithCookie || isPostsToHashtagsWithCookie) {
         // we can run this
         return;
     }
 
     throw `******\nINSTAGRAM SCRAPER DOESN'T WORK FOR SOME INPUTS!\nInstagram changed layout of their page and most input types stopped working\n`
-    + `Currently working inputs:\n\nProfile details\nPost details\nProfile posts (only with login cookies)\n\n`
+    + `Currently working inputs:\n\nProfile details\nPost details\nProfile posts (only with login cookies)\nPlaces Posts (only with login cookies)\nPost comments\nHashtag posts (only with login cookies)\n\n`
     + `We decided to completely disable this scraper until this issue is resolved to prevent further spending of your credits\n`
     + `Some use-cases should be enabled today or tomorrow, most till the end of the week\n`
     + `We will notify you on email once this actor is enabled again\n`

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -557,7 +557,7 @@ const extendFunction = async ({
 
         for (const item of await splitMap(data, merged)) {
             if (filter && !(await filter({ data, item }, merged))) {
-                continue; // eslint-disable-line no-continue
+                continue;
             }
 
             const result = await (evaledFn.runInThisContext()({
@@ -794,20 +794,20 @@ const handleResponse = async (response) => {
 */
 
 const parsePageScript = async (page) => {
-    const scripts = await page.$$eval('script', scripts => scripts.map(script => script.innerHTML));
+    const scripts = await page.$$eval('script', (scripts) => scripts.map((script) => script.innerHTML));
     for (const script of scripts) {
         // parse script with window._sharedData
         if (script.includes('window._sharedData')) {
             const parsedScript = script.replace('window._sharedData = ', '').slice(0, -1);
             return eval(`(${parsedScript})`).entry_data?.ProfilePage?.[0]?.graphql?.user;
-        }
-        // or check the alternative script
-        if (script.includes('highlight_reel_count')) {
+        } if (script.includes('highlight_reel_count')) {
             const json = script.split(`"result":`)?.[1]?.slice(0, -15);
             return eval(`(${JSON.parse(json).response})`).data.user;
+        } if (script.includes('HasteSupportData')) {
+            log.debug('Found HasteSupportData, no shareddata nor highlight_reel_count');
         }
     }
-}
+};
 
 module.exports = {
     getPageTypeFromUrl,

--- a/src/scraper-base.js
+++ b/src/scraper-base.js
@@ -912,12 +912,12 @@ class BaseScraper extends Apify.PuppeteerCrawler {
             while (tries++ < 10) {
                 const scrolled = await Promise.all([
                     page.evaluate(() => window.scrollTo(0, document.body.scrollHeight)),
-                    page.waitForResponse(() => true, { timeout: 2000 }).catch(() => null),
+                    page.waitForResponse(() => true, { timeout: 4000 }).catch(() => null),
                 ]);
 
                 if (!scrolled[1]) {
                     if (tries > 3 && state.hasNextPage) {
-                        throw new Error('No response scrolling for 2s');
+                        throw new Error('No response scrolling for 4s');
                     }
                 } else {
                     break;

--- a/src/scraper-public.js
+++ b/src/scraper-public.js
@@ -308,7 +308,7 @@ class PublicScraper extends BaseScraper {
 
         if (userInfo) pageData = userInfo;
 
-        const state = this.initScrollingState(pageData.id);
+        const state = await this.initScrollingState(pageData.id);
 
         // Get variable we look for in the query string of request
         const checkedVariable = (() => {
@@ -327,7 +327,7 @@ class PublicScraper extends BaseScraper {
          * @param {{ posts: any[], postsCount: number }} timeline
          * @param {Puppeteer.HTTPResponse} [response]
          */
-        const pushPosts = (timeline, response = undefined) => {
+        const pushPosts = async (timeline, response = undefined) => {
             timeline = pageData.edge_owner_to_timeline_media.edges;
             return this.filterPushedItemsAndUpdateState(
                 // timeline.posts,


### PR DESCRIPTION
It should work with cookies for posts, but let's test a bit (I tested with #newyork #losangeles locally). 
The response is different than the previous version, so let's hope they don't revert anything.
Also TIL, `page.reload` causes a bug while scrolling (can't get `scrollHeight`), I lost a good amount of time for that.
