### PR TITLE
Non cookie post details fix

### DIFF
--- a/src/details.js
+++ b/src/details.js
@@ -50,6 +50,15 @@ const sidecarImages = (node) => formatDisplayResources(node.edge_sidecar_to_chil
  * @param {Record<string, any>} node
  */
 const formatSinglePost = (node) => {
+    let productUrl = null;
+
+    if (node.product_type === 'igtv') {
+        productUrl = `https://www.instagram.com/tv/${node.shortcode}`;
+    } else if (node.product_type === 'clips') {
+        productUrl = `https://www.instagram.com/reel/${node.shortcode}`;
+    } else {
+        productUrl = `https://www.instagram.com/p/${node.shortcode}`;
+    }
     const comments = {
         count: [
             node.comment_count,
@@ -78,15 +87,20 @@ const formatSinglePost = (node) => {
         caption,
         hashtags,
         mentions,
-        url: node.shortcode ? `https://www.instagram.com/p/${node.shortcode}/` : null,
+        url: productUrl || null,
         commentsCount: comments.count || comments.edges.length || 0,
-        firstComment: node.comments?.[0]?.text || node.comments?.edges?.[0]?.node?.text || '',
+        firstComment: node.comments?.[0]?.text || node.comments?.edges?.[0]?.node?.text || node?.edge_media_to_parent_comment?.edges?.[0]?.node?.text || '',
         latestComments: node.comments?.length ? node.comments.map(({ pk, user, text, created_at }) => ({
             id: pk ?? null,
             ownerUsername: user?.username ?? '',
             text,
             timestamp: secondsToDate(created_at),
         })) : node.comments?.edges?.length ? node.comments.edges.map(({ node: { id, owner: { username }, text, created_at } }) => ({
+            id,
+            ownerUsername: username,
+            text,
+            timestamp: secondsToDate(created_at),
+        })) : node.edge_media_to_parent_comment?.edges?.length ? node.edge_media_to_parent_comment.edges.map(({ node: { id, owner: { username }, text, created_at } }) => ({
             id,
             ownerUsername: username,
             text,

--- a/src/scraper-base.js
+++ b/src/scraper-base.js
@@ -71,7 +71,7 @@ class BaseScraper extends Apify.PuppeteerCrawler {
                 }
             }],
             preNavigationHooks: [async ({ request, page }, gotoOptions) => {
-                gotoOptions.waitUntil = 'networkidle2';
+                gotoOptions.waitUntil = 'networkidle0';
                 request.userData.isInitial = request.userData.isInitial ? request.userData.isInitial : false;
                 await page.on('response', async (response) => {
                     try {
@@ -201,12 +201,12 @@ class BaseScraper extends Apify.PuppeteerCrawler {
                 }
 
                 if (!userData.isInitial && !userData.userInfo
-                    && ((request.url.includes('/p/') && (rest.input?.resultsType === SCRAPE_TYPES.DETAILS)))
-                && rest.input?.loginCookies?.length) {
+                    && ((request.url.includes('/p/') && (rest.input?.resultsType === SCRAPE_TYPES.DETAILS) && (!userData.nonLoginInfo || !userData.info)))
+                ) {
                     // sometimes need to reload page to get /info/ /user/ request
                     // todo: find a better way to do this
-                    await page.reload({ waitUntil: 'networkidle2' });
-                    await page.waitForTimeout(5000);
+                    await page.reload({ waitUntil: 'domcontentloaded' });
+                    await page.waitForTimeout(1000);
                     userData.isInitial = true;
                 }
 


### PR DESCRIPTION
Fix post details/parsing for non-cookie input. Let's test a bit before latest.

Also, naturally slower than scraping via requests, maybe we should only use plain requests for post/user details as we don't need a browser for those.